### PR TITLE
New procrustes

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
 BSD 3-Clause License
 
-Copyright (c) 2016-2022, QIIME 2 development team.
+Copyright (c) 2016-2023, QIIME 2 development team.
 All rights reserved.
 
 Redistribution and use in source and binary forms, with or without

--- a/q2_diversity/__init__.py
+++ b/q2_diversity/__init__.py
@@ -1,5 +1,5 @@
 # ----------------------------------------------------------------------------
-# Copyright (c) 2016-2022, QIIME 2 development team.
+# Copyright (c) 2016-2023, QIIME 2 development team.
 #
 # Distributed under the terms of the Modified BSD License.
 #

--- a/q2_diversity/__init__.py
+++ b/q2_diversity/__init__.py
@@ -12,7 +12,7 @@ from ._beta import (beta, beta_phylogenetic, bioenv,
                     beta_group_significance, mantel, beta_rarefaction,
                     beta_correlation, adonis)
 from ._ordination import pcoa, pcoa_biplot, tsne, umap
-from ._procrustes import procrustes_analysis
+from ._procrustes import procrustes_analysis, partial_procrustes
 from ._core_metrics import core_metrics_phylogenetic, core_metrics
 from ._filter import filter_distance_matrix
 from ._version import get_versions
@@ -27,5 +27,5 @@ __all__ = ['beta', 'beta_phylogenetic', 'alpha', 'alpha_phylogenetic',
            'core_metrics_phylogenetic', 'core_metrics',
            'filter_distance_matrix', 'mantel', 'alpha_rarefaction',
            'beta_rarefaction', 'procrustes_analysis', 'beta_correlation',
-           'adonis',
+           'adonis', 'partial_procrustes'
            ]

--- a/q2_diversity/_alpha/__init__.py
+++ b/q2_diversity/_alpha/__init__.py
@@ -1,5 +1,5 @@
 # ----------------------------------------------------------------------------
-# Copyright (c) 2016-2022, QIIME 2 development team.
+# Copyright (c) 2016-2023, QIIME 2 development team.
 #
 # Distributed under the terms of the Modified BSD License.
 #

--- a/q2_diversity/_alpha/_pipeline.py
+++ b/q2_diversity/_alpha/_pipeline.py
@@ -1,5 +1,5 @@
 # ----------------------------------------------------------------------------
-# Copyright (c) 2016-2022, QIIME 2 development team.
+# Copyright (c) 2016-2023, QIIME 2 development team.
 #
 # Distributed under the terms of the Modified BSD License.
 #

--- a/q2_diversity/_alpha/_visualizer.py
+++ b/q2_diversity/_alpha/_visualizer.py
@@ -1,5 +1,5 @@
 # ----------------------------------------------------------------------------
-# Copyright (c) 2016-2022, QIIME 2 development team.
+# Copyright (c) 2016-2023, QIIME 2 development team.
 #
 # Distributed under the terms of the Modified BSD License.
 #

--- a/q2_diversity/_beta/__init__.py
+++ b/q2_diversity/_beta/__init__.py
@@ -1,5 +1,5 @@
 # ----------------------------------------------------------------------------
-# Copyright (c) 2016-2022, QIIME 2 development team.
+# Copyright (c) 2016-2023, QIIME 2 development team.
 #
 # Distributed under the terms of the Modified BSD License.
 #

--- a/q2_diversity/_beta/_beta_correlation.py
+++ b/q2_diversity/_beta/_beta_correlation.py
@@ -1,5 +1,5 @@
 # ----------------------------------------------------------------------------
-# Copyright (c) 2016-2022, QIIME 2 development team.
+# Copyright (c) 2016-2023, QIIME 2 development team.
 #
 # Distributed under the terms of the Modified BSD License.
 #

--- a/q2_diversity/_beta/_beta_rarefaction.py
+++ b/q2_diversity/_beta/_beta_rarefaction.py
@@ -1,5 +1,5 @@
 # ----------------------------------------------------------------------------
-# Copyright (c) 2016-2022, QIIME 2 development team.
+# Copyright (c) 2016-2023, QIIME 2 development team.
 #
 # Distributed under the terms of the Modified BSD License.
 #

--- a/q2_diversity/_beta/_pipeline.py
+++ b/q2_diversity/_beta/_pipeline.py
@@ -1,5 +1,5 @@
 # ----------------------------------------------------------------------------
-# Copyright (c) 2016-2022, QIIME 2 development team.
+# Copyright (c) 2016-2023, QIIME 2 development team.
 #
 # Distributed under the terms of the Modified BSD License.
 #

--- a/q2_diversity/_beta/_visualizer.py
+++ b/q2_diversity/_beta/_visualizer.py
@@ -1,5 +1,5 @@
 # ----------------------------------------------------------------------------
-# Copyright (c) 2016-2022, QIIME 2 development team.
+# Copyright (c) 2016-2023, QIIME 2 development team.
 #
 # Distributed under the terms of the Modified BSD License.
 #

--- a/q2_diversity/_core_metrics.py
+++ b/q2_diversity/_core_metrics.py
@@ -1,5 +1,5 @@
 # ----------------------------------------------------------------------------
-# Copyright (c) 2016-2022, QIIME 2 development team.
+# Copyright (c) 2016-2023, QIIME 2 development team.
 #
 # Distributed under the terms of the Modified BSD License.
 #

--- a/q2_diversity/_examples.py
+++ b/q2_diversity/_examples.py
@@ -1,5 +1,5 @@
 # ----------------------------------------------------------------------------
-# Copyright (c) 2016-2022, QIIME 2 development team.
+# Copyright (c) 2016-2023, QIIME 2 development team.
 #
 # Distributed under the terms of the Modified BSD License.
 #

--- a/q2_diversity/_examples.py
+++ b/q2_diversity/_examples.py
@@ -6,15 +6,13 @@
 # The full license is in the file LICENSE, distributed with this software.
 # ----------------------------------------------------------------------------
 
-import qiime2
-
 
 # PD Mice Data
 pd_alpha_div_faith_pd_url = ('https://data.qiime2.org/usage-examples/pd-mice/'
                              'core-metrics-results/faith_pd_vector.qza')
 
-pd_metadata_url = (f'https://data.qiime2.org/{qiime2.__release__}/tutorials/'
-                   'pd-mice/sample_metadata.tsv')
+pd_metadata_url = ('https://data.qiime2.org/usage-examples/'
+                   'pd-mice/sample-metadata.tsv')
 
 
 # Alpha Diversity examples

--- a/q2_diversity/_filter.py
+++ b/q2_diversity/_filter.py
@@ -1,5 +1,5 @@
 # ----------------------------------------------------------------------------
-# Copyright (c) 2016-2022, QIIME 2 development team.
+# Copyright (c) 2016-2023, QIIME 2 development team.
 #
 # Distributed under the terms of the Modified BSD License.
 #

--- a/q2_diversity/_ordination.py
+++ b/q2_diversity/_ordination.py
@@ -1,5 +1,5 @@
 # ----------------------------------------------------------------------------
-# Copyright (c) 2016-2022, QIIME 2 development team.
+# Copyright (c) 2016-2023, QIIME 2 development team.
 #
 # Distributed under the terms of the Modified BSD License.
 #

--- a/q2_diversity/_procrustes.py
+++ b/q2_diversity/_procrustes.py
@@ -1,5 +1,5 @@
 # ----------------------------------------------------------------------------
-# Copyright (c) 2016-2022, QIIME 2 development team.
+# Copyright (c) 2016-2023, QIIME 2 development team.
 #
 # Distributed under the terms of the Modified BSD License.
 #

--- a/q2_diversity/_procrustes.py
+++ b/q2_diversity/_procrustes.py
@@ -117,11 +117,9 @@ def _procrustes_monte_carlo(reference: np.ndarray, other: np.ndarray,
     return df
 
 
-def deconstructed_procrustes(mtx1: np.array,
-                             mtx2: np.array) -> (np.ndarray, np.ndarray,
-                                                 float, float, np.ndarray,
-                                                 float):
-    """Derived from scipy procrustes."""
+def _deconstructed_procrustes(mtx1, mtx2):
+    # Derived from scipy procrustes
+    # https://github.com/scipy/scipy/blob/d541c752246a9e196034957d3e044950eec75907/scipy/spatial/_procrustes.py#L100-L125
     mtx1 = mtx1.copy()
     mtx2 = mtx2.copy()
 
@@ -147,10 +145,7 @@ def deconstructed_procrustes(mtx1: np.array,
     return mtx1_translate, mtx2_translate, norm1, norm2, R, s
 
 
-def partial_procrustes(df_mtx1: pd.DataFrame,
-                       df_mtx2: pd.DataFrame,
-                       df_mtx1_pair_ids: list,
-                       df_mtx2_pair_ids: list) -> (pd.DataFrame, pd.DataFrame):
+def _partial_procrustes(df_mtx1, df_mtx2, df_mtx1_pair_ids, df_mtx2_pair_ids):
     df_mtx1 = df_mtx1.copy()
     df_mtx2 = df_mtx2.copy()
 
@@ -159,7 +154,7 @@ def partial_procrustes(df_mtx1: pd.DataFrame,
     paired_mtx2 = df_mtx2.loc[df_mtx2_pair_ids]
 
     # compute procrustes on paired data
-    results = deconstructed_procrustes(paired_mtx1, paired_mtx2)
+    results = _deconstructed_procrustes(paired_mtx1, paired_mtx2)
     mtx1_translate, mtx2_translate, norm1, norm2, R, s = results
 
     # transform both full input matrices

--- a/q2_diversity/plugin_setup.py
+++ b/q2_diversity/plugin_setup.py
@@ -1,5 +1,5 @@
 # ----------------------------------------------------------------------------
-# Copyright (c) 2016-2022, QIIME 2 development team.
+# Copyright (c) 2016-2023, QIIME 2 development team.
 #
 # Distributed under the terms of the Modified BSD License.
 #

--- a/q2_diversity/plugin_setup.py
+++ b/q2_diversity/plugin_setup.py
@@ -377,8 +377,7 @@ plugin.methods.register_function(
     parameter_descriptions={
         'dimensions': ('The number of dimensions to use when fitting the two '
                        'matrices'),
-        'pairing': ("The metadata column describing the pair a sample may "
-                    "sample pairs.")
+        'pairing': ("The metadata column describing sample pairs which exist.")
     },
     output_descriptions={
         'transformed': ("The 'other' ordination transformed into the space of "

--- a/q2_diversity/plugin_setup.py
+++ b/q2_diversity/plugin_setup.py
@@ -357,6 +357,39 @@ plugin.methods.register_function(
     description='Fit two ordination matrices with Procrustes analysis'
 )
 
+plugin.methods.register_function(
+    function=q2_diversity.partial_procrustes,
+    inputs={'reference': PCoAResults,
+            'other': PCoAResults,
+    },
+    parameters={
+        'dimensions': Int % Range(1, None),
+        'pairing': MetadataColumn[Categorical],
+    },
+    outputs=[
+        ('transformed', PCoAResults),
+    ],
+    input_descriptions={
+        'reference': ('The ordination matrix to which data is fitted to.'),
+        'other': ("The ordination matrix that's fitted to the reference "
+                  "ordination."),
+    },
+    parameter_descriptions={
+        'dimensions': ('The number of dimensions to use when fitting the two '
+                       'matrices'),
+        'pairing': ("The metadata column describing the pair a sample may "
+                    "sample pairs.")
+    },
+    output_descriptions={
+        'transformed': ("The 'other' ordination transformed into the space of "
+                        "the reference ordination."),
+    },
+    name='Partial Procrustes',
+    description=('Transform one ordination into another, using paired samples '
+                 'to anchor the transformation. This method allows does not '
+                 'require all samples to be paired.')
+)
+
 plugin.pipelines.register_function(
     function=q2_diversity.core_metrics_phylogenetic,
     inputs={

--- a/q2_diversity/tests/__init__.py
+++ b/q2_diversity/tests/__init__.py
@@ -1,5 +1,5 @@
 # ----------------------------------------------------------------------------
-# Copyright (c) 2016-2022, QIIME 2 development team.
+# Copyright (c) 2016-2023, QIIME 2 development team.
 #
 # Distributed under the terms of the Modified BSD License.
 #

--- a/q2_diversity/tests/test_adonis.py
+++ b/q2_diversity/tests/test_adonis.py
@@ -1,5 +1,5 @@
 # ----------------------------------------------------------------------------
-# Copyright (c) 2016-2022, QIIME 2 development team.
+# Copyright (c) 2016-2023, QIIME 2 development team.
 #
 # Distributed under the terms of the Modified BSD License.
 #

--- a/q2_diversity/tests/test_alpha.py
+++ b/q2_diversity/tests/test_alpha.py
@@ -1,5 +1,5 @@
 # ----------------------------------------------------------------------------
-# Copyright (c) 2016-2022, QIIME 2 development team.
+# Copyright (c) 2016-2023, QIIME 2 development team.
 #
 # Distributed under the terms of the Modified BSD License.
 #

--- a/q2_diversity/tests/test_alpha_rarefaction.py
+++ b/q2_diversity/tests/test_alpha_rarefaction.py
@@ -1,5 +1,5 @@
 # ----------------------------------------------------------------------------
-# Copyright (c) 2016-2022, QIIME 2 development team.
+# Copyright (c) 2016-2023, QIIME 2 development team.
 #
 # Distributed under the terms of the Modified BSD License.
 #

--- a/q2_diversity/tests/test_beta.py
+++ b/q2_diversity/tests/test_beta.py
@@ -1,5 +1,5 @@
 # ----------------------------------------------------------------------------
-# Copyright (c) 2016-2022, QIIME 2 development team.
+# Copyright (c) 2016-2023, QIIME 2 development team.
 #
 # Distributed under the terms of the Modified BSD License.
 #

--- a/q2_diversity/tests/test_beta_correlation.py
+++ b/q2_diversity/tests/test_beta_correlation.py
@@ -1,5 +1,5 @@
 # ----------------------------------------------------------------------------
-# Copyright (c) 2016-2022, QIIME 2 development team.
+# Copyright (c) 2016-2023, QIIME 2 development team.
 #
 # Distributed under the terms of the Modified BSD License.
 #

--- a/q2_diversity/tests/test_beta_rarefaction.py
+++ b/q2_diversity/tests/test_beta_rarefaction.py
@@ -1,5 +1,5 @@
 # ----------------------------------------------------------------------------
-# Copyright (c) 2016-2022, QIIME 2 development team.
+# Copyright (c) 2016-2023, QIIME 2 development team.
 #
 # Distributed under the terms of the Modified BSD License.
 #

--- a/q2_diversity/tests/test_core_metrics.py
+++ b/q2_diversity/tests/test_core_metrics.py
@@ -1,5 +1,5 @@
 # ----------------------------------------------------------------------------
-# Copyright (c) 2016-2022, QIIME 2 development team.
+# Copyright (c) 2016-2023, QIIME 2 development team.
 #
 # Distributed under the terms of the Modified BSD License.
 #

--- a/q2_diversity/tests/test_filter.py
+++ b/q2_diversity/tests/test_filter.py
@@ -1,5 +1,5 @@
 # ----------------------------------------------------------------------------
-# Copyright (c) 2016-2022, QIIME 2 development team.
+# Copyright (c) 2016-2023, QIIME 2 development team.
 #
 # Distributed under the terms of the Modified BSD License.
 #

--- a/q2_diversity/tests/test_ordination.py
+++ b/q2_diversity/tests/test_ordination.py
@@ -1,5 +1,5 @@
 # ----------------------------------------------------------------------------
-# Copyright (c) 2016-2022, QIIME 2 development team.
+# Copyright (c) 2016-2023, QIIME 2 development team.
 #
 # Distributed under the terms of the Modified BSD License.
 #

--- a/q2_diversity/tests/test_plugin_setup.py
+++ b/q2_diversity/tests/test_plugin_setup.py
@@ -1,5 +1,5 @@
 # ----------------------------------------------------------------------------
-# Copyright (c) 2016-2022, QIIME 2 development team.
+# Copyright (c) 2016-2023, QIIME 2 development team.
 #
 # Distributed under the terms of the Modified BSD License.
 #

--- a/q2_diversity/tests/test_procrustes.py
+++ b/q2_diversity/tests/test_procrustes.py
@@ -1,5 +1,5 @@
 # ----------------------------------------------------------------------------
-# Copyright (c) 2016-2022, QIIME 2 development team.
+# Copyright (c) 2016-2023, QIIME 2 development team.
 #
 # Distributed under the terms of the Modified BSD License.
 #

--- a/setup.py
+++ b/setup.py
@@ -1,5 +1,5 @@
 # ----------------------------------------------------------------------------
-# Copyright (c) 2016-2022, QIIME 2 development team.
+# Copyright (c) 2016-2023, QIIME 2 development team.
 #
 # Distributed under the terms of the Modified BSD License.
 #


### PR DESCRIPTION
Tests and an action to drive the method

@gibsramen, how's this look? 

We could compute disparity for the paired samples, but it isn't directly usable in emperor as its procrustes action requires two ordinations for input. In this case, we merge the ordination space into a single object (which I think is what we want to do...)